### PR TITLE
Added third argument to Permissions.create

### DIFF
--- a/Files.js
+++ b/Files.js
@@ -1,26 +1,9 @@
 import RNFS from "react-native-fs";
 import utf8 from "utf8";
-import {
-   StaticUtils,
-   ArrayStringifier
-} from "simple-common-utils";
+import { StaticUtils } from "simple-common-utils";
 import GDrive from "./GDrive";
 
 const uploadUrl = "https://www.googleapis.com/upload/drive/v3/files";
-
-function _stringifyQueryParams(queryParams,
-   prefix = "?", separator = "&", quoteIfString)
-{
-   const array = [];
-   
-   Object.keys(queryParams).forEach(key => array.push(
-      `${key}=${StaticUtils.safeQuoteIfString(queryParams[key], quoteIfString)}`));
-   
-   return new ArrayStringifier(array)
-      .setPrefix(prefix)
-      .setSeparator(separator)
-      .process();
-}
 
 export default class Files {
    static mimeFolder = "application/vnd.google-apps.folder";
@@ -105,7 +88,7 @@ export default class Files {
       }
       
       let result = await this.list({
-         q: _stringifyQueryParams(queryParams, "",
+         q: GDrive._stringifyQueryParams(queryParams, "",
             " and ", true) + ` and '${parents[0]}' in parents`
       });
       
@@ -119,7 +102,7 @@ export default class Files {
    }
    
    get(fileId, queryParams) {
-      const parameters = _stringifyQueryParams(queryParams);
+      const parameters = GDrive._stringifyQueryParams(queryParams);
       
       return fetch(`${GDrive._urlFiles}/${fileId}${parameters}`, {
          headers: GDrive._createHeaders()
@@ -129,7 +112,7 @@ export default class Files {
    download(fileId, downloadFileOptions, queryParams = {}) {
       queryParams.alt = "media";
       
-      const parameters = _stringifyQueryParams(queryParams);
+      const parameters = GDrive._stringifyQueryParams(queryParams);
       
       downloadFileOptions.fromUrl = `${GDrive._urlFiles}/${fileId}${parameters}`;
       
@@ -141,7 +124,7 @@ export default class Files {
    }
    
    list(queryParams) {
-      return fetch(`${GDrive._urlFiles}${_stringifyQueryParams(queryParams)}`, {
+      return fetch(`${GDrive._urlFiles}${GDrive._stringifyQueryParams(queryParams)}`, {
          headers: GDrive._createHeaders()
       });
    }

--- a/GDrive.js
+++ b/GDrive.js
@@ -1,5 +1,9 @@
 import Files from "./Files";
 import Permissions from "./Permissions";
+import {
+   StaticUtils,
+   ArrayStringifier
+} from "simple-common-utils";
 
 export default class GDrive {
    static _urlFiles = "https://www.googleapis.com/drive/v3/files";
@@ -39,5 +43,17 @@ export default class GDrive {
       }
       
       return headers;
+   }
+
+   static _stringifyQueryParams(queryParams, prefix = "?", separator = "&", quoteIfString) {
+      const array = [];
+
+      Object.keys(queryParams).forEach(key => array.push(
+         `${key}=${StaticUtils.safeQuoteIfString(queryParams[key], quoteIfString)}`));
+      
+      return new ArrayStringifier(array)
+         .setPrefix(prefix)
+         .setSeparator(separator)
+         .process();
    }
 }

--- a/Permissions.js
+++ b/Permissions.js
@@ -29,8 +29,6 @@ export default class Permissions {
          finalQueryParams = _stringifyQueryParams(queryParams);
       }
 
-      console.log('URL BRE', `${GDrive._urlFiles}/${fileId}${permissions}${finalQueryParams}`);
-
       return fetch(`${GDrive._urlFiles}/${fileId}${permissions}${finalQueryParams}`, {
          method: "POST",
          headers: GDrive._createHeaders(

--- a/Permissions.js
+++ b/Permissions.js
@@ -5,13 +5,10 @@ const permissions = "/permissions";
 export default class Permissions {
    create(fileId, params, queryParams) {
       const body = JSON.stringify(params);
-      
-      let finalQueryParams = '';
-      if (queryParams) {
-         finalQueryParams = GDrive._stringifyQueryParams(queryParams);
-      }
 
-      return fetch(`${GDrive._urlFiles}/${fileId}${permissions}${finalQueryParams}`, {
+      queryParams = queryParams ? GDrive._stringifyQueryParams(queryParams) : "";
+
+      return fetch(`${GDrive._urlFiles}/${fileId}${permissions}${queryParams}`, {
          method: "POST",
          headers: GDrive._createHeaders(
             GDrive._contentTypeJson,

--- a/Permissions.js
+++ b/Permissions.js
@@ -1,24 +1,6 @@
 import GDrive from "./GDrive";
-import {
-   StaticUtils,
-   ArrayStringifier
-} from "simple-common-utils";
 
 const permissions = "/permissions";
-
-function _stringifyQueryParams(queryParams,
-   prefix = "?", separator = "&", quoteIfString)
-{
-   const array = [];
-   
-   Object.keys(queryParams).forEach(key => array.push(
-      `${key}=${StaticUtils.safeQuoteIfString(queryParams[key], quoteIfString)}`));
-   
-   return new ArrayStringifier(array)
-      .setPrefix(prefix)
-      .setSeparator(separator)
-      .process();
-}
 
 export default class Permissions {
    create(fileId, params, queryParams) {
@@ -26,7 +8,7 @@ export default class Permissions {
       
       let finalQueryParams = '';
       if (queryParams) {
-         finalQueryParams = _stringifyQueryParams(queryParams);
+         finalQueryParams = GDrive._stringifyQueryParams(queryParams);
       }
 
       return fetch(`${GDrive._urlFiles}/${fileId}${permissions}${finalQueryParams}`, {

--- a/Permissions.js
+++ b/Permissions.js
@@ -4,7 +4,6 @@ const permissions = "/permissions";
 
 export default class Permissions {
    create(fileId, params) {
-      console.log('vvvv');
       const body = JSON.stringify(params);
       
       return fetch(`${GDrive._urlFiles}/${fileId}${permissions}`, {

--- a/Permissions.js
+++ b/Permissions.js
@@ -1,12 +1,37 @@
 import GDrive from "./GDrive";
+import {
+   StaticUtils,
+   ArrayStringifier
+} from "simple-common-utils";
 
 const permissions = "/permissions";
 
+function _stringifyQueryParams(queryParams,
+   prefix = "?", separator = "&", quoteIfString)
+{
+   const array = [];
+   
+   Object.keys(queryParams).forEach(key => array.push(
+      `${key}=${StaticUtils.safeQuoteIfString(queryParams[key], quoteIfString)}`));
+   
+   return new ArrayStringifier(array)
+      .setPrefix(prefix)
+      .setSeparator(separator)
+      .process();
+}
+
 export default class Permissions {
-   create(fileId, params) {
+   create(fileId, params, queryParams) {
       const body = JSON.stringify(params);
       
-      return fetch(`${GDrive._urlFiles}/${fileId}${permissions}`, {
+      let finalQueryParams = '';
+      if (queryParams) {
+         finalQueryParams = _stringifyQueryParams(queryParams);
+      }
+
+      console.log('URL BRE', `${GDrive._urlFiles}/${fileId}${permissions}${finalQueryParams}`);
+
+      return fetch(`${GDrive._urlFiles}/${fileId}${permissions}${finalQueryParams}`, {
          method: "POST",
          headers: GDrive._createHeaders(
             GDrive._contentTypeJson,

--- a/Permissions.js
+++ b/Permissions.js
@@ -4,6 +4,7 @@ const permissions = "/permissions";
 
 export default class Permissions {
    create(fileId, params) {
+      console.log('vvvv');
       const body = JSON.stringify(params);
       
       return fetch(`${GDrive._urlFiles}/${fileId}${permissions}`, {

--- a/README.md
+++ b/README.md
@@ -137,8 +137,11 @@ This is the "entry point" of the wrapper. It contains only `static` methods and 
 	
         GDrive.permissions.create(
             fileId, {
+                emailAddress: 'example@gmail.com',
                 role: "reader",
                 type: "anyone"
+            }, {
+                emailMessage: `I shared a file with you.`,
             });
 
 


### PR DESCRIPTION
Third argument will let us give query params to create()

These query params are described [here](https://developers.google.com/drive/api/v3/reference/permissions/create#parameters)

For example:

- sendNotificationEmail: boolean
- emailMessage: string
- etc.

Example:

```
// API: https://bit.ly/3ejth32
const permissionsResponse = await GDrive.permissions.create(
    newFileId,
    {
        emailAddress: 'example@gmail.com',
        type: "user",
        role: "writer", // reader, writer, owner, commenter, organizer, fileOrganizer
    },
    {
        sendNotificationEmail: true,
        emailMessage: 'I gave you access', // A plain text custom message to include in the notification email.
    }
);

```

I am repeating _stringifyQueryParams so I dont change too many files, but can refactor that if you wish.

Cheers,
Misha